### PR TITLE
User registration bug fixes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,11 +10,15 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      # session[:user_id] = @user.id
+      session[:user_id] = @user.id
       redirect_to user_path(@user)
+      flash[:notice] = "Welcome #{@user.name}"
+    elsif params[:password] != params[:password_confirmation]
+      flash[:failture] = "Error: Password doesn't match."
+      render :new
     else
-      redirect_to '/register'
-      flash[:alert] = "Error: #{@user.errors.full_messages.first}"
+      flash[:failure] = @user.errors.full_messages.first
+      render :new
     end
   end
 
@@ -33,7 +37,7 @@ class UsersController < ApplicationController
 
   private 
   def user_params
-    params.permit(:email, :name, :password)
+    params.permit(:email, :name, :password, :password_confirmation)
   end
 
   def set_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :user_parties
   has_many :parties, through: :user_parties
   validates :name, :email, presence: true
+  validates_uniqueness_of :email
   has_secure_password
 end
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,10 +1,12 @@
 <h1>Create New User</h1>
-<%= form_with url: users_path, method: :post do |f| %>
+<%= form_with url: users_path, method: :post, local: true do |f| %>
   <%= f.label :name, "Name" %>
   <%= f.text_field :name %>
   <%= f.label :email, "Email" %>
   <%= f.text_field :email %>
   <%= f.label :password, "Password" %>
   <%= f.text_field :password %>
+  <%= f.label :password_confirmation, "Re-Enter Password" %>
+  <%= f.text_field :password_confirmation %>
   <%= f.submit "Create User" %>
 <% end %>

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -50,6 +50,27 @@ RSpec.describe 'user registration page', type: :feature do
           expect(current_path).to eq('/users')
           expect(page).to have_content("Name can't be blank")
         end
+
+        it "If the user tried to use an email address that's already been taken they are not allowed to sign up." do
+          visit new_user_path
+
+          fill_in(:name, with: "Peter Piper")
+          fill_in(:email, with: "Peter.Piper@peppers.com")
+          fill_in(:password, with: "IlovePeppers")
+          fill_in(:password_confirmation, with: "IlovePeppers")
+
+          click_on('Create User')
+          click_on('Home Page')
+          click_on('New User')
+
+          fill_in(:name, with: "Megan Piper")
+          fill_in(:email, with: "Peter.Piper@peppers.com")
+          fill_in(:password, with: "IlovePeppers!")
+          fill_in(:password_confirmation, with: "IlovePeppers!")
+          click_on('Create User')
+
+          expect(page).to have_content("Email has already been taken")
+        end
       end
 
     end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe 'user registration page', type: :feature do
 
       describe 'happy path' do
         it "Once the user registers they should be taken to a dashboard page '/users/:id', where :id is the id for the user that was just created." do
-          visit new_user_path #here is where I left off - first thing tomorrow 
+          visit new_user_path 
           fill_in(:name, with: "Peter Piper")
           fill_in(:email, with: "Peter.Piper@peppers.com")
           fill_in(:password, with: "IlovePeppers")
+          fill_in(:password_confirmation, with: "IlovePeppers")
+
           click_on('Create User')
           user4 = create(:user, password_digest:BCrypt::Password.create('IlovecOde2!'))
 
@@ -42,9 +44,11 @@ RSpec.describe 'user registration page', type: :feature do
           #missing name fill in
           fill_in(:email, with: "Peter.Piper@peppers.com")
           fill_in(:password, with: "IlovePeppers")
+          fill_in(:password_confirmation, with: "IlovePeppers")
+
           click_on('Create User')
-          expect(current_path).to eq('/register')
-          expect(page).to have_content("Error: Name can't be blank")
+          expect(current_path).to eq('/users')
+          expect(page).to have_content("Name can't be blank")
         end
       end
 


### PR DESCRIPTION
This PR will fix the user registration flash message bugs that were happening. It will also create a password confirmation field so you must retype your password, thus, making it more secure. And It will block a user from reusing an email address that was already taken.

All tests are passing & local host is working.